### PR TITLE
roll over: 0.18 -> 0.19

### DIFF
--- a/.github/workflows/spack-v0.19.0.yml
+++ b/.github/workflows/spack-v0.19.0.yml
@@ -1,4 +1,4 @@
-name: spack-v0.18.0
+name: spack-v0.19.0
 
 on:
   push:
@@ -18,5 +18,5 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
-      run: make spack-v0.18.0
+      run: make spack-v0.19.0
       

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ spack-latest:
 	docker build -f Dockerfile --build-arg SPACK_VERSION=releases/latest \
 	-t octopus-spack-latest .
 
-spack-v0.18.0:
-	docker build -f Dockerfile --build-arg SPACK_VERSION=v0.18.0 \
-   -t octopus-spack-v0.18.0 .
+spack-v0.19.0:
+	docker build -f Dockerfile --build-arg SPACK_VERSION=v0.19.0 \
+   -t octopus-spack-v0.19.0 .
 
 spack-v0.18.1:
 	docker build -f Dockerfile --build-arg SPACK_VERSION=v0.18.1 \
@@ -19,4 +19,4 @@ spack-v0.18.1:
 run:
 	docker run --rm -ti -v $PWD:/io octopus-spack 
 
-.PHONY: octopus-spack-v0.18.1 run spack-v0.18.0 spack-latest spack-develop
+.PHONY: octopus-spack-v0.18.1 run spack-v0.19.0 spack-latest spack-develop

--- a/README.rst
+++ b/README.rst
@@ -30,10 +30,11 @@ would install if we run `spack install octopus`).
 
 We try different versions of Spack:
 
-- |spack-develop-octopus-stable| Spack develop version (git head), Octopus 12.0
-- |spack-latest-octopus-stable| Spack latest release (=0.18.1), Octopus 11.4
+- |spack-develop-octopus-stable| Spack develop version (git head), Octopus 12.1
+- |spack-latest-octopus-stable| Spack latest release (=0.19.0), Octopus 11.4
+- |spack-v0.19.0-octopus-stable| Spack release 0.19.0, Octopus 11.4
 - |spack-v0.18.1-octopus-stable| Spack release 0.18.1, Octopus 11.4
-- |spack-v0.18.0-octopus-stable| Spack release 0.18.0, Octopus 11.4
+
 
 .. |spack-latest-octopus-stable| image:: https://github.com/fangohr/octopus-in-spack/actions/workflows/spack-latest.yml/badge.svg
    :target: https://github.com/fangohr/spack-ci-octopus/actions/workflows/spack-latest.yml


### PR DESCRIPTION
Integrate new spack release. Minor updates to version numbers.